### PR TITLE
Migration cider namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ```clojure
 [adzerk/boot-cljs-repl   "0.3.3"] ;; latest release
-[cider/piggieback        "0.3.5"  :scope "test"]
+[cider/piggieback        "0.3.9"  :scope "test"]
 [weasel                  "0.7.0"  :scope "test"]
-[nrepl                   "0.3.1"  :scope "test"]
+[nrepl                   "0.4.5"  :scope "test"]
 ```
 
 [Boot] task providing a ClojureScript browser REPL via [Weasel] and [Piggieback].

--- a/build.boot
+++ b/build.boot
@@ -1,8 +1,8 @@
 (set-env!
   :resource-paths #{"src"}
-  :dependencies '[[cider/piggieback "0.3.5" :scope "test"]
+  :dependencies '[[cider/piggieback "0.3.9" :scope "test"]
                   [weasel           "0.7.0" :scope "test"]
-                  [nrepl            "0.3.1" :scope "test"]])
+                  [nrepl            "0.4.5" :scope "test"]])
 
 (def +version+ "0.5.0-SNAPSHOT")
 

--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -16,9 +16,9 @@
 (def ^:private out-file (atom nil))
 
 (def ^:private deps
-  '[[cider/piggieback "0.3.5" :scope "test"]
+  '[[cider/piggieback "0.3.9" :scope "test"]
     [weasel           "0.7.0" :scope "test"]
-    [nrepl            "0.3.1" :scope "test"]])
+    [nrepl            "0.4.5" :scope "test"]])
 
 (defn- assert-deps
   "Advices user to add direct deps to requires deps if they

--- a/src/adzerk/boot_cljs_repl.clj
+++ b/src/adzerk/boot_cljs_repl.clj
@@ -197,5 +197,5 @@
     ;; FIXME: concat :middleware?
     (apply repl (mapcat identity (merge nrepl-opts
                                         {:server true
-                                         :middleware ['cemerick.piggieback/wrap-cljs-repl]})))
+                                         :middleware ['cider.piggieback/wrap-cljs-repl]})))
     (apply cljs-repl-env (mapcat identity (dissoc *opts* :nrepl-opts)))))


### PR DESCRIPTION
#adzerk-oss/boot-cljs-repl#61

Still referenced `cemerick.piggieback/wrap-cljs-repl`.

Updated dependencies to latest, unless there is good reason to stay with `nrepl [0.3.1]` as `org.clojure/tools.nrepl [0.2.13]` drop-in replacement.